### PR TITLE
Shorten page names

### DIFF
--- a/.vuepress/1.x.js
+++ b/.vuepress/1.x.js
@@ -10,8 +10,8 @@ module.exports = [
         title: "Features",
         collapsable: false,
         children: prefix('features', [
-            'authentication',
-            'profile-management',
+            'access',
+            'profiles',
             'security',
             'api',
             'teams',

--- a/1.x/features/access.md
+++ b/1.x/features/access.md
@@ -1,4 +1,4 @@
-# Authentication
+# Access
 
 [[toc]]
 

--- a/1.x/features/profiles.md
+++ b/1.x/features/profiles.md
@@ -1,4 +1,4 @@
-# Profile Management
+# Profiles
 
 [[toc]]
 


### PR DESCRIPTION
Small tweak to make the nav items more aligned

`Profile Management` -> `Profiles`
`Authentication` -> `Access`

Just a thought 

![shorten](https://user-images.githubusercontent.com/29180903/92836866-e595a180-f3aa-11ea-84dc-ee2c28859f8c.png)

