### PR TITLE
Create oauth.md

### DIFF
--- a/1.x/features/oauth.md
+++ b/1.x/features/oauth.md
@@ -1,0 +1,27 @@
+# oAuth
+
+[[toc]]
+
+## Introduction
+
+Jetstream includes first-party integration with [Socialite](https://laravel.com/docs/socialite). Laravel Socialite provides a simple way to oAuth with services such as Facebook and Twitter. Laravel Jetstream's oAuth features provides registration / login using 3rd party providers and an interface for connecting and disconnecting oAuth accounts.
+
+![Screenshot of Laravel Jetstream oAuth Login](./../../assets/img/oauth-login.png)
+
+![Screenshot of Laravel Jetstream oAuth Connected Accounts](./../../assets/img/oauth-connected-accounts.png)
+
+## Views / Pages
+
+When using the Livewire stack, the view for login icons is displayed using `resources/views/components/socialite.blade.php` Blade template. For authenticated users, the connected accounts view is displayed using the `resources/views/profile/connected-accounts-form.blade.php` Blade template. 
+
+When using the Inertia stack, the view for login icons is displayed using `resources/js/Jestream/Socialite.vue`. For authenticated users, the connected accounts view is displayed using the `resources/js/Jetstream/ConnectedAccountsForm.vue` template.
+
+## Enabling oAuth Support
+
+If you wish to allow users to login using oAuth, you must first configure your oAuth providers per the [Socialite docs](https://laravel.com/docs/socialite). Secondly, you must enable the feature in your `/config/jetstream.php` configuration file. To enable this feature, simply uncomment the feature entry from the `features` configuration item within this file:
+
+```php
+'features' => [
+    // Features::socialite(['facebook' => true, 'github' => true]),
+],
+```


### PR DESCRIPTION
Incase oAuth is still being considered for v2, I just wanted to jumpstart the docs.
I didn't see a v2 folder so I just put it in v1 for now.

---

I wasn't sure how detailed to be. For example, if to include docs for: 

```php
Auth::user()->getTokenFor('facebook')
```