### PR TITLE
Remove token check from Authorization example

### DIFF
--- a/2.x/features/teams.md
+++ b/2.x/features/teams.md
@@ -187,8 +187,7 @@ Of course, you will need a way to authorize that incoming requests initiated by 
 **There is typically not a need to inspect a user's role. You only need to inspect that the user has a given granular permission.** Roles are simply a presentational concept used to group granular permissions. Typically, you will execute calls to this method within your application's [authorization policies](https://laravel.com/docs/authorization):
 
 ```php
-return $request->user()->hasTeamPermission($server->team, 'server:update') &&
-       $request->user()->tokenCan('server:update');
+return $user->hasTeamPermission($server->team, 'server:update');
 ```
 
 ### Combining Team Permissions With API Permissions


### PR DESCRIPTION
Developers who are _not_ using the API permissions addressed in the next section won't check `tokenCan`. It's just a tiny thing, but it's a little more intuitive for paste-and-change learners like myself.