### PR TITLE
Fix Typo in email verification

### DIFF
--- a/2.x/features/registration.md
+++ b/2.x/features/registration.md
@@ -127,5 +127,5 @@ Once these two setup steps have been completed, newly registered users will rece
 
 :::tip Laravel Mail
 
-Before using the password reset feature, you should ensure that your Laravel application is configured to [send emails](https://laravel.com/docs/mail). Otherwise, Laravel will not be able to send email verification links to your application's users.
+Before using the email verification feature, you should ensure that your Laravel application is configured to [send emails](https://laravel.com/docs/mail). Otherwise, Laravel will not be able to send email verification links to your application's users.
 :::


### PR DESCRIPTION
At https://jetstream.laravel.com/2.x/features/registration.html#email-verification is "password reset feature" used instead of "email verification feature".
This PR fixes the typo