### PR TITLE
Point out that only team owners can manage team membership by default

### DIFF
--- a/2.x/features/teams.md
+++ b/2.x/features/teams.md
@@ -111,7 +111,7 @@ $team->userHasPermission($user, $permission) : bool
 
 ## Member Management
 
-Team members may be added and removed from a team via Jetstream's "Team Settings" view.
+Team members may be added and removed from a team via Jetstream's "Team Settings" view. Only team owners can manage membership by default. This is defined in `app\Policies\TeamPolicy::addTeamMember`. Naturally, you are free to modify this policy as you see fit.
 
 ### Member Management Actions
 

--- a/2.x/features/teams.md
+++ b/2.x/features/teams.md
@@ -111,7 +111,7 @@ $team->userHasPermission($user, $permission) : bool
 
 ## Member Management
 
-Team members may be added and removed from a team via Jetstream's "Team Settings" view. Only team owners can manage membership by default. This is defined in `app\Policies\TeamPolicy::addTeamMember`. Naturally, you are free to modify this policy as you see fit.
+Team members may be added and removed from a team via Jetstream's "Team Settings" view. By default, only team owners can manage team membership. This restriction is defined in the `App\Policies\TeamPolicy` class. Naturally, you are free to modify this policy as you see fit.
 
 ### Member Management Actions
 


### PR DESCRIPTION
When setting up Jetstream with teams, it is not totally clear what the 'admin' role means. One might think that an admin for a team would include team membership management, but it doesn't (it is, in fact, a whole different security model). This minor change to the docs brings that to light and proposes a way to let people change the policy.