### PR TITLE
Fix search context to only search 2.x docs

### DIFF
--- a/.vuepress/theme/index.js
+++ b/.vuepress/theme/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+    extend: '@vuepress/theme-default',
+
+    plugins: [
+        ['@vuepress/search', {
+            test: ['/2\.x/'],
+        }]
+    ],
+}


### PR DESCRIPTION
Fixes an issue where search results may return 1.x and 2.x results.

Fixes https://github.com/laravel/jetstream/issues/705