### PR TITLE
Fix sidebar overlapping content

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -17,9 +17,6 @@ h2
 /* Page
 -----------------------------------------------------------------------------*/
 @media (min-width 720px)
-  .page
-    padding-left 13.75rem
-
   .page-edit
     // display none
 


### PR DESCRIPTION
I recently stumbled upon a small annoyance when browsing the docs: the sidebar overlaps the content area once the viewport goes bellow `1200px`:

https://www.loom.com/share/c6751f75c39e476c9f073df03eae519a