### PR TITLE
Add basic Ziggy route() usage information

### DIFF
--- a/2.x/stacks/inertia.md
+++ b/2.x/stacks/inertia.md
@@ -103,3 +103,15 @@ To illustrate the use of modals, consider the following modal that confirms a us
 ```
 
 As you can see, the modal's open / close state is determined by a `show` property that is declared on the component. The modal's contents may be specified by hydrating three slots: `title`, `content`, and `footer`.
+
+## Routes
+
+You may need to refer to your named routes in your application, either in your templates or in your application JavaScript. Jetstream's Intertia stack includes Tighten's Ziggy library as a JavaScript alternative to the Laravel `route()` helper.
+
+You can refer to their [usage documentation](https://github.com/tighten/ziggy#usage) for the complete guide, but some common examples can be found in the Jetstream Vue files, including `Layouts/AppLayout.vue`:
+
+```html
+<jet-nav-link :href="route('dashboard')" :active="route().current('dashboard')">
+    Dashboard
+</jet-nav-link>
+```

--- a/2.x/stacks/inertia.md
+++ b/2.x/stacks/inertia.md
@@ -106,9 +106,7 @@ As you can see, the modal's open / close state is determined by a `show` propert
 
 ## Routes
 
-You may need to refer to your named routes in your application, either in your templates or in your application JavaScript. Jetstream's Intertia stack includes Tighten's Ziggy library as a JavaScript alternative to the Laravel `route()` helper.
-
-You can refer to their [usage documentation](https://github.com/tighten/ziggy#usage) for the complete guide, but some common examples can be found in the Jetstream Vue files, including `Layouts/AppLayout.vue`:
+Jetstream's Intertia stack includes Tighten's Ziggy library as a JavaScript alternative to the Laravel `route()` helper. You can refer to the [Ziggy usage documentation](https://github.com/tighten/ziggy#usage) for a complete guide on using this library, but some common examples can be found in Jetstream's own Vue files, including `Layouts/AppLayout.vue`:
 
 ```html
 <jet-nav-link :href="route('dashboard')" :active="route().current('dashboard')">


### PR DESCRIPTION
This is a fairly heavily-used feature of the Jetstream Inertia stack, but is currently undocumented. The upstream Ziggy docs are ideal for long-term/detailed usage information, but it was not obvious to me where the `route()` function was coming from or how to properly use it outside of what was in the initial Jetstream Vue files.

I don't know if this is the right place for this to go in the documentation, but it made the most sense to me.