### PR TITLE
Fix heading level for "Banner Alerts" section

### DIFF
--- a/2.x/building-your-app.md
+++ b/2.x/building-your-app.md
@@ -47,7 +47,7 @@ When team support is enabled, Jetstream includes a screen that allows users to m
 
 When using Livewire, the team settings screen is defined by the `resources/views/teams/show.blade.php` Blade template. When using Inertia, this screen is rendered by the `resources/js/Pages/Teams/Show.vue` component.
 
-### Banner Alerts
+## Banner Alerts
 
 Jetstream includes a notification banner which can be displayed at the top of your application's UI. If you are using the Livewire stack, you should ensure this notification banner has been published using the `vendor:publish` command:
 


### PR DESCRIPTION
The `Banner Alerts` section is currently shown as a child heading of the `Team Management`, causing confusion in the table of contents. This PR changes the heading level from three to two, making it a section of its own.

Here is a screenshot of the current documentation page
![image](https://user-images.githubusercontent.com/95144705/166065891-d3aec7ef-e0ef-4597-b53c-27cf87f4ff02.png)
And here is what I think it should look like (and what my fix does)
![image](https://user-images.githubusercontent.com/95144705/166066010-2d35dd29-93de-4899-b0fe-11dc494a9e23.png)

This is the page in reference: https://jetstream.laravel.com/2.x/building-your-app.html#banner-alerts