### PR TITLE
Change method's name

### DIFF
--- a/2.x/features/teams.md
+++ b/2.x/features/teams.md
@@ -196,13 +196,13 @@ When building a Jetstream application that provides both API support and team su
 
 ```php
 /**
- * Determine whether the user can update a flight.
+ * Determine whether the user can view a flight.
  *
  * @param  \App\Models\User  $user
  * @param  \App\Models\Flight  $flight
  * @return bool
  */
-public function update(User $user, Flight $flight)
+public function view(User $user, Flight $flight)
 {
     return $user->belongsToTeam($flight->team) &&
            $user->hasTeamPermission($flight->team, 'flight:view') &&

--- a/2.x/features/teams.md
+++ b/2.x/features/teams.md
@@ -202,7 +202,7 @@ When building a Jetstream application that provides both API support and team su
  * @param  \App\Models\Flight  $flight
  * @return bool
  */
-public function view(User $user, Flight $flight)
+public function update(User $user, Flight $flight)
 {
     return $user->belongsToTeam($flight->team) &&
            $user->hasTeamPermission($flight->team, 'flight:view') &&


### PR DESCRIPTION
Hey there.

Really tiny fix. I think that the method's name in the example of **Combining Team Permissions With API Permissions** should be named "update" because the comment is talking about "update a flight".