### PR TITLE
Reference the Vite docs

### DIFF
--- a/2.x/installation.md
+++ b/2.x/installation.md
@@ -45,7 +45,7 @@ The Inertia stack may also be installed with SSR support:
 php artisan jetstream:install inertia --ssr
 ```
 
-You can read more about running the SSR server in the [Laravel Vite plugin documentation](https://laravel.com/docs/vite#ssr) and over on the [Inertia documentation site](https://inertiajs.com/server-side-rendering).
+You can read more about running the SSR server in the [Laravel Vite plugin documentation](https://laravel.com/docs/vite#ssr) and within the [Inertia documentation](https://inertiajs.com/server-side-rendering).
 
 ### Finalizing The Installation
 

--- a/2.x/installation.md
+++ b/2.x/installation.md
@@ -45,7 +45,7 @@ The Inertia stack may also be installed with SSR support:
 php artisan jetstream:install inertia --ssr
 ```
 
-You can read more about running the SSR server in the [Laravel Vite plugin documentation](https://laravel.com/docs/vite#ssr) and within the [Inertia documentation](https://inertiajs.com/server-side-rendering).
+You can read more about running the SSR server in the [Laravel Vite plugin](https://laravel.com/docs/vite#ssr) and [Inertia](https://inertiajs.com/server-side-rendering) documentation.
 
 ### Finalizing The Installation
 

--- a/2.x/installation.md
+++ b/2.x/installation.md
@@ -39,11 +39,13 @@ php artisan jetstream:install inertia
 php artisan jetstream:install inertia --teams
 ```
 
-The Inertia stack may also be installed with [SSR support](https://inertiajs.com/server-side-rendering):
+The Inertia stack may also be installed with SSR support:
 
 ```bash
 php artisan jetstream:install inertia --ssr
 ```
+
+You can read more about running the SSR server in the [Laravel Vite plugin documentation](https://laravel.com/docs/vite#ssr) and over on the [Inertia documentation site](https://inertiajs.com/server-side-rendering).
 
 ### Finalizing The Installation
 


### PR DESCRIPTION
As the Inertia docs have to cover a lot of information regarding SSR generally (servers, npm packages etc), I felt it might be good to just also point people to the Vite docs directly, as that contains a much more focused version of what they will need to do. The inertia docs go into a lot of detail, where as the only thing you need to do with Jetstream is:

1. When intially creating your application:

`php artisan jetstream:install inertia --ssr`

2. Build your assets:

`npm run build`

3. Start the SSR server

`node /home/forge/{site}/bootstrap/ssr/ssr.mjs`

Which is essentially what is covered in the Vite docs.

Additionally, the Inertia docs are not up to date right now, so this is a nice stop gap (will send a PR shortly to update the docs).


![Screen Shot 2022-07-28 at 10 24 09 am](https://user-images.githubusercontent.com/24803032/181394962-82c201a7-e658-43d4-9522-e63cbbdb19fe.png)

