### PR TITLE
[3.x] Fix redirect from `3.x` to introduction page

### DIFF
--- a/3.x/README.md
+++ b/3.x/README.md
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0;url=/2.x/introduction.html" />
+<meta http-equiv="refresh" content="0;url=/3.x/introduction.html" />


### PR DESCRIPTION
This fixes the redirect I missed for https://jetstream.laravel.com/3.x to https://jetstream.laravel.com/3.x/introduction.html.

The redirect from https://jetstream.laravel.com to https://jetstream.laravel.com/3.x/introduction.html is fine though.