### PR TITLE
Include `composer create-project` command in installation example

### DIFF
--- a/1.x/installation.md
+++ b/1.x/installation.md
@@ -7,6 +7,7 @@
 You may use Composer to install Jetstream into your new Laravel project:
 
 ```bash
+composer create-project laravel/laravel <your-project-name>
 composer require laravel/jetstream
 ```
 

--- a/2.x/installation.md
+++ b/2.x/installation.md
@@ -7,6 +7,7 @@
 You may use Composer to install Jetstream into your new Laravel project:
 
 ```bash
+composer create-project laravel/laravel <your-project-name>
 composer require laravel/jetstream
 ```
 

--- a/3.x/installation.md
+++ b/3.x/installation.md
@@ -7,7 +7,8 @@
 You may use Composer to install Jetstream into your new Laravel project:
 
 ```bash
-composer create-project laravel/laravel <your-project-name>
+composer create-project laravel/laravel example-app
+
 composer require laravel/jetstream
 ```
 

--- a/3.x/installation.md
+++ b/3.x/installation.md
@@ -7,6 +7,7 @@
 You may use Composer to install Jetstream into your new Laravel project:
 
 ```bash
+composer create-project laravel/laravel <your-project-name>
 composer require laravel/jetstream
 ```
 


### PR DESCRIPTION
I am new to the Laravel ecosystem, and the wording _install Jetstream into your new Laravel project_ contradicted the red warning box further down in the [Installation docs](https://jetstream.laravel.com/3.x/installation.html) about "Jetstream should only be installed into new Laravel applications." In my mind, the ambiguity was "do I need to include the Laravel framework _first_ before I `composer require` Jetstream?"

Again, new to the ecosystem, so I wasn't sure if the `artisan` command only came from the Laravel framework. My assumption was that "creating a new Laravel project" would mean that Jetstream included the necessary bits to start a new Laravel project, and that I _shouldn't_ start with `composer create-project laravel/laravel`.

After asking a couple people, I was informed that I was wrong, and that _yes_, I need to create a Laravel project first, before installing Jetstream. I figure that revising the docs may clear up any ambiguity for other new users.