### PR TITLE
Add missing `cd` command to install Jetstream

### DIFF
--- a/3.x/installation.md
+++ b/3.x/installation.md
@@ -9,6 +9,8 @@ You may use Composer to install Jetstream into your new Laravel project:
 ```bash
 composer create-project laravel/laravel example-app
 
+cd example-app
+
 composer require laravel/jetstream
 ```
 


### PR DESCRIPTION
Small doc addition for new users showing them that they must `cd` into their newly generated app folder to install Jetstream.