### PR TITLE
Fix registration docs using the wrong Features class

### DIFF
--- a/1.x/features/registration.md
+++ b/1.x/features/registration.md
@@ -89,7 +89,7 @@ Many application require users to accept their terms of service / privacy policy
 To get started, enable this feature in your application's `config/jetstream.php` configuration file:
 
 ```php
-use Laravel\Fortify\Features;
+use Laravel\Jetstream\Features;
 
 'features' => [
     Features::termsAndPrivacyPolicy(),

--- a/2.x/features/registration.md
+++ b/2.x/features/registration.md
@@ -87,7 +87,7 @@ Many applications require users to accept their terms of service / privacy polic
 To get started, enable this feature in your application's `config/jetstream.php` configuration file:
 
 ```php
-use Laravel\Fortify\Features;
+use Laravel\Jetstream\Features;
 
 'features' => [
     Features::termsAndPrivacyPolicy(),

--- a/3.x/features/registration.md
+++ b/3.x/features/registration.md
@@ -87,7 +87,7 @@ Many applications require users to accept their terms of service / privacy polic
 To get started, enable this feature in your application's `config/jetstream.php` configuration file:
 
 ```php
-use Laravel\Fortify\Features;
+use Laravel\Jetstream\Features;
 
 'features' => [
     Features::termsAndPrivacyPolicy(),


### PR DESCRIPTION
### Fixed

- Fixes importing the wrong `Features` class in the example for `config/jetstream.php`