### PR TITLE
Fix: unknown command "build"

### DIFF
--- a/3.x/installation.md
+++ b/3.x/installation.md
@@ -65,7 +65,7 @@ After installing Jetstream, you should install and build your NPM dependencies a
 
 ```bash
 npm install
-npm run build
+npm run prod
 php artisan migrate
 ```
 


### PR DESCRIPTION
When I run the `build` command, an error appears saying the command does not exist.

So I checked and found that the correct command should be `prod` (or `dev`)

<img width="563" alt="image" src="https://github.com/laravel/jetstream-docs/assets/5250117/1be14fe5-313f-4479-83b8-00bf38a9ef07">
