### PR TITLE
Fix URL for the Livewire screencasts

### DIFF
--- a/src/introduction.md
+++ b/src/introduction.md
@@ -22,7 +22,7 @@ When using Livewire, you may pick and choose which portions of your application 
 
 :::tip Livewire Screencasts
 
-If you're new to Livewire, check out the [screencasts available on the Livewire website](https://livewire.laravel.com/screencasts/installation).
+If you're new to Livewire, check out the [screencasts available on the Livewire website](https://laravel-livewire.com/screencasts/installation).
 :::
 
 ### Inertia + Vue


### PR DESCRIPTION
The URL for the Livewire screencasts is leading to a "route not found" error.