### PR TITLE
Fix reference to 4.x

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -71,7 +71,7 @@ export default defineConfigWithTheme<ThemeConfig>({
                 link: 'https://jetstream.laravel.com',
                 current: true,
             },
-            { text: 'v4.x', link: 'https://github.com/laravel/jetstream-docs/tree/4.x' },
+            { text: 'v4.x', link: 'https://github.com/laravel/jetstream-docs/tree/61cfcca' },
             { text: 'v3.x', link: 'https://github.com/laravel/jetstream-docs/tree/3.x' },
             { text: 'v2.x', link: 'https://github.com/laravel/jetstream-docs/tree/2.x' },
             { text: 'v1.x', link: 'https://github.com/laravel/jetstream-docs/tree/1.x' },


### PR DESCRIPTION
Since there is no `4.x` branch the versions dropdown in the navigation bar links version `4.x` to a `404` GitHub page:

---
![jetstream_version_dropdown](https://github.com/laravel/jetstream-docs/assets/4658706/5724a695-fe7b-4785-b705-4d2ffde710db)

---

![github_jetstream_docs_missing_ref](https://github.com/laravel/jetstream-docs/assets/4658706/aaa4c679-b675-4af3-9d6e-60d923bfe599)

---

This PR links to a commit of version `4.x` instead. (I think the [commit](https://github.com/laravel/jetstream-docs/tree/61cfcca) is of version `4.x`, please check.)

Alternative would be to actually create branch/tag `4.x` retrospectively?


