### PR TITLE
Separate normal install command and "teams" command

### DIFF
--- a/src/installation.md
+++ b/src/installation.md
@@ -30,7 +30,11 @@ Jetstream should only be installed into new Laravel applications. Attempting to 
 
 ```bash
 php artisan jetstream:install livewire
+```
 
+If you would like "teams" support, you can provide the `--teams` directive to the install command:
+
+```bash
 php artisan jetstream:install livewire --teams
 ```
 
@@ -38,7 +42,11 @@ php artisan jetstream:install livewire --teams
 
 ```bash
 php artisan jetstream:install inertia
+```
 
+If you would like "teams" support with the Inertia stack, provide the `--teams` directive to the install command:
+
+```bash
 php artisan jetstream:install inertia --teams
 ```
 


### PR DESCRIPTION
When I was installing Jetstream I accidentally ran multiple install commands because both the normal one and the "team" ones were in the same code block and I'm in the habit of copying and pasting install code blocks like that:

```bash
php artisan jetstream:install livewire

php artisan jetstream:install livewire --teams
```

I didn't realize until I was farther down the install and there were overlapping migrations.

Anyhow, take it or leave it, just threw it in here to help the next person