### PR TITLE
authentication.md: Bring default pipeline definition up to date

### DIFF
--- a/src/features/authentication.md
+++ b/src/features/authentication.md
@@ -110,16 +110,19 @@ The example below contains the default pipeline definition that you may use as a
 
 ```php
 use Laravel\Fortify\Actions\AttemptToAuthenticate;
+use Laravel\Fortify\Actions\CanonicalizeUsername;
 use Laravel\Fortify\Actions\EnsureLoginIsNotThrottled;
 use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
+use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
 use Illuminate\Http\Request;
 
 Fortify::authenticateThrough(function (Request $request) {
     return array_filter([
             config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
-            RedirectIfTwoFactorAuthenticatable::class,
+            config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,
+            Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
             AttemptToAuthenticate::class,
             PrepareAuthenticatedSession::class,
     ]);


### PR DESCRIPTION
ref: https://github.com/laravel/docs/pull/9816
I don't know if it's necessary to check for two factor authentication to be enabled before setting RedirectIfTwoFactorAuthenticatable but as it is done this way both in Laravel Fortify docs and in the Fortify source code, I have updated it here to be like this.